### PR TITLE
Allow RootCause to honor Convert

### DIFF
--- a/werror.go
+++ b/werror.go
@@ -62,7 +62,7 @@ func Convert(err error) error {
 	case *werror:
 		return err
 	default:
-		return Error(err.Error())
+		return newWerror("", err)
 	}
 }
 
@@ -191,6 +191,9 @@ func newWerror(message string, cause error, params ...Param) error {
 func (e *werror) Error() string {
 	if e.cause == nil {
 		return e.message
+	}
+	if e.message == "" {
+		return e.cause.Error()
 	}
 	return e.message + ": " + e.cause.Error()
 }

--- a/werror.go
+++ b/werror.go
@@ -273,16 +273,20 @@ func (e *werror) formatCause(state fmt.State, verb rune) {
 	if e.cause == nil {
 		return
 	}
+	var prefix string
+	if e.message != "" || (verb == 'v' && len(e.params) > 0) {
+		prefix = ": "
+	}
 	switch verb {
 	case 'v':
 		if state.Flag('+') {
 			fmt.Fprintf(state, "%+v\n", e.cause)
 		} else {
-			fmt.Fprintf(state, ": %v", e.cause)
+			fmt.Fprintf(state, "%s%v", prefix, e.cause)
 		}
 	case 's':
-		fmt.Fprintf(state, ": %s", e.cause)
+		fmt.Fprintf(state, "%s%s", prefix, e.cause)
 	case 'q':
-		fmt.Fprintf(state, ": %q", e.cause)
+		fmt.Fprintf(state, "%s%q", prefix, e.cause)
 	}
 }

--- a/werror_test.go
+++ b/werror_test.go
@@ -115,6 +115,69 @@ testing.tRunner
 runtime.goexit
 	.+$`,
 		},
+		{
+			name: "wrapped with empty string",
+			err: werror.Wrap(
+				werror.Error("rootcause"),
+				"",
+			),
+			stringified: "rootcause",
+			verbose:     `rootcause`,
+			extraVerboseRegexp: `^rootcause
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+
+
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+$`,
+		},
+		{
+			name: "wrapped with empty string and params",
+			err: werror.Wrap(
+				werror.Error("rootcause"),
+				"",
+				werror.SafeParam("safeEmptyWrapperKey", "safeEmptyWrapperValue"),
+				werror.UnsafeParam("unsafeWrapperKey", "unsafeWrapperValue"),
+			),
+			stringified: "rootcause",
+			verbose:     `map[safeEmptyWrapperKey:safeEmptyWrapperValue]: rootcause`,
+			extraVerboseRegexp: `^rootcause
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+
+map\[safeEmptyWrapperKey:safeEmptyWrapperValue\]
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+$`,
+		},
+		{
+			name: "converted custom error",
+			err: werror.Convert(
+				fmt.Errorf("customErr"),
+			),
+			stringified: "customErr",
+			verbose:     `customErr`,
+			extraVerboseRegexp: `^customErr
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+$`,
+		},
 	} {
 		t.Run(currCase.name, func(t *testing.T) {
 			require.Error(t, currCase.err)

--- a/werror_test.go
+++ b/werror_test.go
@@ -164,6 +164,25 @@ runtime.goexit
 	.+$`,
 		},
 		{
+			name: "wrapped custom error with params",
+			err: werror.Wrap(
+				fmt.Errorf("customErr"),
+				"wrapper",
+				werror.SafeParam("safeWrapperKey", "safeWrapperValue"),
+				werror.UnsafeParam("unsafeWrapperKey", "unsafeWrapperValue"),
+			),
+			stringified: "wrapper: customErr",
+			verbose:     `wrapper map[safeWrapperKey:safeWrapperValue]: customErr`,
+			extraVerboseRegexp: `^customErr
+wrapper map\[safeWrapperKey:safeWrapperValue\]
+` + pkgPath + `_test.TestError_Format
+	.+
+testing.tRunner
+	.+
+runtime.goexit
+	.+$`,
+		},
+		{
 			name: "converted custom error",
 			err: werror.Convert(
 				fmt.Errorf("customErr"),

--- a/werror_test.go
+++ b/werror_test.go
@@ -419,6 +419,10 @@ func TestRootCause(t *testing.T) {
 		rootCause error
 		err       error
 	}{{
+		name:      "nil error",
+		rootCause: nil,
+		err:       nil,
+	}, {
 		name:      "new werror error",
 		rootCause: werrorErr,
 		err:       werrorErr,
@@ -427,6 +431,10 @@ func TestRootCause(t *testing.T) {
 		rootCause: werrorErr,
 		err:       werror.Wrap(werrorErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
 	}, {
+		name:      "converted werror error",
+		rootCause: werrorErr,
+		err:       werror.Convert(werrorErr),
+	}, {
 		name:      "custom error",
 		rootCause: customErr,
 		err:       customErr,
@@ -434,6 +442,10 @@ func TestRootCause(t *testing.T) {
 		name:      "wrapped custom error",
 		rootCause: customErr,
 		err:       werror.Wrap(customErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
+	}, {
+		name:      "converted custom error",
+		rootCause: customErr,
+		err:       werror.Convert(customErr),
 	}} {
 		t.Run(currCase.name, func(t *testing.T) {
 			assert.Equal(t, currCase.rootCause, werror.RootCause(currCase.err))

--- a/werror_test.go
+++ b/werror_test.go
@@ -190,6 +190,7 @@ runtime.goexit
 			stringified: "customErr",
 			verbose:     `customErr`,
 			extraVerboseRegexp: `^customErr
+
 ` + pkgPath + `_test.TestError_Format
 	.+
 testing.tRunner


### PR DESCRIPTION
This PR allows a non-werror error passed to `Convert` to be recovered by `RootCause`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/6)
<!-- Reviewable:end -->
