### PR TITLE
Add werror error printer

### DIFF
--- a/werror_printer.go
+++ b/werror_printer.go
@@ -7,8 +7,8 @@ import (
 )
 
 func GenerateErrorString(err error, outputEveryCallingStack bool) string {
-	if zerror, ok := err.(*werror); ok {
-		return generateZerrorString(zerror, outputEveryCallingStack)
+	if werror, ok := err.(*werror); ok {
+		return generateWerrorString(werror, outputEveryCallingStack)
 	}
 	if fancy, ok := err.(fmt.Formatter); ok {
 		// This is a rich error type, like those produced by github.com/pkg/errors.
@@ -17,7 +17,7 @@ func GenerateErrorString(err error, outputEveryCallingStack bool) string {
 	return err.Error()
 }
 
-func generateZerrorString(err *werror, outputEveryCallingStack bool) string {
+func generateWerrorString(err *werror, outputEveryCallingStack bool) string {
 	var buffer bytes.Buffer
 	writeMessage(err, &buffer)
 	writeParams(err, &buffer)

--- a/werror_printer.go
+++ b/werror_printer.go
@@ -6,6 +6,13 @@ import (
 	"sort"
 )
 
+// GenerateErrorString will attempt to pretty print an error depending on its underlying type
+// If it is a werror then:
+// 1) Each message and params will be groups together on a separate line
+// 2) Only the deepest werror stacktrace will be printed
+// 3) GenerateErrorString will be called recursively to pretty print underlying errors as well
+// If the error implements the fmt.Formatter interface, then it will be printed verbosely
+// Otherwise, the error's underlying Error() function will be called and returned
 func GenerateErrorString(err error, outputEveryCallingStack bool) string {
 	if werror, ok := err.(*werror); ok {
 		return generateWerrorString(werror, outputEveryCallingStack)

--- a/werror_printer.go
+++ b/werror_printer.go
@@ -1,0 +1,73 @@
+package werror
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+func GenerateErrorString(err error, outputEveryCallingStack bool) string {
+	if zerror, ok := err.(*werror); ok {
+		return generateZerrorString(zerror, outputEveryCallingStack)
+	}
+	if fancy, ok := err.(fmt.Formatter); ok {
+		// This is a rich error type, like those produced by github.com/pkg/errors.
+		return fmt.Sprintf("%+v", fancy)
+	}
+	return err.Error()
+}
+
+func generateZerrorString(err *werror, outputEveryCallingStack bool) string {
+	var buffer bytes.Buffer
+	writeMessage(err, &buffer)
+	writeParams(err, &buffer)
+	writeCause(err, &buffer, outputEveryCallingStack)
+	writeStack(err, &buffer, outputEveryCallingStack)
+	return buffer.String()
+}
+
+func writeMessage(err *werror, buffer *bytes.Buffer) {
+	if err.message == "" {
+		return
+	}
+	buffer.WriteString(err.message)
+}
+
+func writeParams(err *werror, buffer *bytes.Buffer) {
+	safeParams := err.SafeParams()
+	var safeKeys []string
+	for k := range safeParams {
+		safeKeys = append(safeKeys, k)
+	}
+	sort.Strings(safeKeys)
+	messageAndParams := err.message != "" && len(safeParams) != 0
+	messageOrParams := err.message != "" || len(safeParams) != 0
+	if messageAndParams {
+		buffer.WriteString(" ")
+	}
+	for _, safeKey := range safeKeys {
+		buffer.WriteString(fmt.Sprintf("%+v:%+v", safeKey, safeParams[safeKey]))
+		// If it is not the last param, add a separator
+		if !(safeKeys[len(safeKeys)-1] == safeKey) {
+			buffer.WriteString(", ")
+		}
+	}
+	if messageOrParams {
+		buffer.WriteString("\n")
+	}
+}
+
+func writeCause(err *werror, buffer *bytes.Buffer, outputEveryCallingStack bool) {
+	if err.cause != nil {
+		buffer.WriteString(GenerateErrorString(err.cause, outputEveryCallingStack))
+	}
+}
+
+func writeStack(err *werror, buffer *bytes.Buffer, outputEveryCallingStack bool) {
+	if _, ok := err.cause.(*werror); ok {
+		if !outputEveryCallingStack {
+			return
+		}
+	}
+	buffer.WriteString(fmt.Sprintf("%+v", err.stack))
+}

--- a/werror_printer_test.go
+++ b/werror_printer_test.go
@@ -1,0 +1,79 @@
+package werror
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const stackTraceString = ".*github.com/palantir/witchcraft-go-error.TestErrorFormatting\n" +
+	".*github.com/palantir/witchcraft-go-error/werror_printer_test.*\n" +
+	"testing.tRunner\n" +
+	".*src/testing/testing.go.*\n" +
+	"runtime.goexit\n" +
+	".*src/runtime.*"
+
+func TestErrorFormatting(t *testing.T) {
+	for _, currCase := range []struct {
+		name                    string
+		err                     error
+		expectedRegex           string
+		outputEveryCallingStack bool
+	}{
+		{
+			name: "simple error",
+			err:  Error("simple_error"),
+			expectedRegex: "" +
+				"simple_error\n\n" +
+				stackTraceString,
+		},
+		{
+			name: "simple error with param",
+			err:  Error("simple_error", SafeParam("safeParamKey", "safeParamValue")),
+			expectedRegex: "" +
+				"simple_error safeParamKey:safeParamValue\n\n" +
+				stackTraceString,
+		},
+		{
+			name: "simple error with many params",
+			err:  Error("simple_error", SafeParam("safeParamKey", "safeParamValue"), SafeParam("safeParamKey2", "safeParamValue2")),
+			expectedRegex: "" +
+				"simple_error safeParamKey:safeParamValue, safeParamKey2:safeParamValue2\n\n" +
+				stackTraceString,
+		},
+		{
+			name: "simple wrapped error",
+			err:  Wrap(Error("simple_error"), "simple_error_2"),
+			expectedRegex: "" +
+				"simple_error_2\n" +
+				"simple_error\n\n" +
+				stackTraceString,
+		},
+		{
+			name: "simple wrapped error with forced stacks",
+			err:  Wrap(Error("simple_error"), "simple_error_2"),
+			expectedRegex: "" +
+				"simple_error_2\n" +
+				"simple_error\n\n" +
+				stackTraceString +
+				"\n" +
+				stackTraceString,
+			outputEveryCallingStack: true,
+		},
+		{
+			name: "double wrapped error with params",
+			err: Wrap(Wrap(
+				Error("inner0Message", SafeParam("inner0ParamKey", "inner0VParamValue"), SafeParam("inner0ParamKey1", "inner0VParamValue1"), SafeParam("inner0ParamKey2", "inner0VParamValue2")),
+				"inner1Message", SafeParam("inner1ParamKey", "inner1ValueKey")), "inner2Message"),
+			expectedRegex: "" +
+				"inner2Message\n" +
+				"inner1Message inner1ParamKey:inner1ValueKey\n" +
+				"inner0Message inner0ParamKey:inner0VParamValue, inner0ParamKey1:inner0VParamValue1, inner0ParamKey2:inner0VParamValue2\n\n" +
+				stackTraceString,
+		},
+	} {
+		t.Run(currCase.name, func(t *testing.T) {
+			assert.Regexp(t, currCase.expectedRegex, GenerateErrorString(currCase.err, currCase.outputEveryCallingStack))
+		})
+	}
+}


### PR DESCRIPTION
-Add werror error printer 
- This printer will de-dupe stacktraces and also print params with the message they are associated with

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/13)
<!-- Reviewable:end -->
