### PR TITLE
Add WrapWithContext and ErrorWithContext functions

### DIFF
--- a/changelog/@unreleased/pr-33.v2.yml
+++ b/changelog/@unreleased/pr-33.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add WrapWithContext and ErrorWithContext functions
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/33

--- a/werror.go
+++ b/werror.go
@@ -2,6 +2,7 @@
 package werror
 
 import (
+	"context"
 	"fmt"
 
 	wparams "github.com/palantir/witchcraft-go-params"
@@ -19,8 +20,20 @@ import (
 //		return werror.Error("configuration is missing password")
 //	}
 //
+// DEPRECATED: Please use ErrorWithContext instead to get full params
 func Error(msg string, params ...Param) error {
 	return newWerror(msg, nil, params...)
+}
+
+// ErrorWithContext is identical to Error but also pulls safe and unsafe params out of the context
+func ErrorWithContext(ctx context.Context, msg string, params ...Param) error {
+	safe, unsafe := wparams.SafeAndUnsafeParamsFromContext(ctx)
+	fullParams := []Param{
+		SafeParams(safe),
+		UnsafeParams(unsafe),
+	}
+	fullParams = append(fullParams, params...)
+	return Error(msg, fullParams...)
 }
 
 // Wrap returns a new error with the provided message and stores the provided error as its cause.
@@ -35,11 +48,23 @@ func Error(msg string, params ...Param) error {
 //		return werror.Wrap(err, "failed to get user", werror.SafeParam("userId", userID))
 //	}
 //
+// DEPRECATED: Please use WrapWithContext instead to get full params
 func Wrap(err error, msg string, params ...Param) error {
 	if err == nil {
 		return nil
 	}
 	return newWerror(msg, err, params...)
+}
+
+// WrapWithContext is identical to Wrap but also pulls safe and unsafe params out of the context
+func WrapWithContext(ctx context.Context, err error, msg string, params ...Param) error {
+	safe, unsafe := wparams.SafeAndUnsafeParamsFromContext(ctx)
+	fullParams := []Param{
+		SafeParams(safe),
+		UnsafeParams(unsafe),
+	}
+	fullParams = append(fullParams, params...)
+	return Wrap(err, msg, fullParams...)
 }
 
 // Convert err to werror error.

--- a/werror.go
+++ b/werror.go
@@ -8,7 +8,14 @@ import (
 	wparams "github.com/palantir/witchcraft-go-params"
 )
 
-// Error returns a new error with the provided message and parameters.
+// Error is identical to ErrorWithContext except it does move params from the context to the error
+// DEPRECATED: Please use ErrorWithContext instead to get full params
+func Error(msg string, params ...Param) error {
+	return newWerror(msg, nil, params...)
+}
+
+// ErrorWithContext returns a new error with the provided message and parameters
+// It also removes any stored params off the context and adds them to the error
 //
 // The message should not contain any formatted parameters -- instead, use the SafeParam* or UnsafeParam* functions
 // to create error parameters.
@@ -17,15 +24,9 @@ import (
 //
 //	password, ok := config["password"]
 //	if !ok {
-//		return werror.Error("configuration is missing password")
+//		return werror.ErrorWithContext(ctx, "configuration is missing password")
 //	}
 //
-// DEPRECATED: Please use ErrorWithContext instead to get full params
-func Error(msg string, params ...Param) error {
-	return newWerror(msg, nil, params...)
-}
-
-// ErrorWithContext is identical to Error but also pulls safe and unsafe params out of the context
 func ErrorWithContext(ctx context.Context, msg string, params ...Param) error {
 	safe, unsafe := wparams.SafeAndUnsafeParamsFromContext(ctx)
 	fullParams := []Param{
@@ -36,7 +37,17 @@ func ErrorWithContext(ctx context.Context, msg string, params ...Param) error {
 	return Error(msg, fullParams...)
 }
 
-// Wrap returns a new error with the provided message and stores the provided error as its cause.
+// Wrap is identical to WrapWithContext except it does move params from the context to the error
+// DEPRECATED: Please use WrapWithContext instead to get full params
+func Wrap(err error, msg string, params ...Param) error {
+	if err == nil {
+		return nil
+	}
+	return newWerror(msg, err, params...)
+}
+
+// WrapWithContext returns a new error with the provided message and stores the provided error as its cause.
+// It also removes any stored params off the context and adds them to the error
 //
 // The message should not contain any formatted parameters -- instead use the SafeParam* or UnsafeParam* functions
 // to create error parameters.
@@ -48,15 +59,6 @@ func ErrorWithContext(ctx context.Context, msg string, params ...Param) error {
 //		return werror.Wrap(err, "failed to get user", werror.SafeParam("userId", userID))
 //	}
 //
-// DEPRECATED: Please use WrapWithContext instead to get full params
-func Wrap(err error, msg string, params ...Param) error {
-	if err == nil {
-		return nil
-	}
-	return newWerror(msg, err, params...)
-}
-
-// WrapWithContext is identical to Wrap but also pulls safe and unsafe params out of the context
 func WrapWithContext(ctx context.Context, err error, msg string, params ...Param) error {
 	safe, unsafe := wparams.SafeAndUnsafeParamsFromContext(ctx)
 	fullParams := []Param{

--- a/werror.go
+++ b/werror.go
@@ -35,7 +35,7 @@ func ErrorWithContextParams(ctx context.Context, msg string, params ...Param) er
 		UnsafeParams(unsafe),
 	}
 	fullParams = append(fullParams, params...)
-	return newWerror(msg, nil, params...)
+	return newWerror(msg, nil, fullParams...)
 }
 
 // Wrap is identical to calling WrapWithContextParams with a context that does not have any wparams parameters.
@@ -68,7 +68,7 @@ func WrapWithContextParams(ctx context.Context, err error, msg string, params ..
 		UnsafeParams(unsafe),
 	}
 	fullParams = append(fullParams, params...)
-	return newWerror(msg, err, params...)
+	return newWerror(msg, err, fullParams...)
 }
 
 // Convert err to werror error.

--- a/werror_printer_test.go
+++ b/werror_printer_test.go
@@ -1,6 +1,7 @@
 package werror
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,28 +23,28 @@ func TestErrorFormatting(t *testing.T) {
 	}{
 		{
 			name: "simple error",
-			err:  Error("simple_error"),
+			err:  ErrorWithContextParams(context.Background(), "simple_error"),
 			expectedRegex: "" +
 				"simple_error\n\n" +
 				stackTraceString,
 		},
 		{
 			name: "simple error with param",
-			err:  Error("simple_error", SafeParam("safeParamKey", "safeParamValue")),
+			err:  ErrorWithContextParams(context.Background(), "simple_error", SafeParam("safeParamKey", "safeParamValue")),
 			expectedRegex: "" +
 				"simple_error safeParamKey:safeParamValue\n\n" +
 				stackTraceString,
 		},
 		{
 			name: "simple error with many params",
-			err:  Error("simple_error", SafeParam("safeParamKey", "safeParamValue"), SafeParam("safeParamKey2", "safeParamValue2")),
+			err:  ErrorWithContextParams(context.Background(), "simple_error", SafeParam("safeParamKey", "safeParamValue"), SafeParam("safeParamKey2", "safeParamValue2")),
 			expectedRegex: "" +
 				"simple_error safeParamKey:safeParamValue, safeParamKey2:safeParamValue2\n\n" +
 				stackTraceString,
 		},
 		{
 			name: "simple wrapped error",
-			err:  Wrap(Error("simple_error"), "simple_error_2"),
+			err:  WrapWithContextParams(context.Background(), ErrorWithContextParams(context.Background(), "simple_error"), "simple_error_2"),
 			expectedRegex: "" +
 				"simple_error_2\n" +
 				"simple_error\n\n" +
@@ -51,7 +52,7 @@ func TestErrorFormatting(t *testing.T) {
 		},
 		{
 			name: "simple wrapped error with forced stacks",
-			err:  Wrap(Error("simple_error"), "simple_error_2"),
+			err:  WrapWithContextParams(context.Background(), ErrorWithContextParams(context.Background(), "simple_error"), "simple_error_2"),
 			expectedRegex: "" +
 				"simple_error_2\n" +
 				"simple_error\n\n" +
@@ -62,8 +63,8 @@ func TestErrorFormatting(t *testing.T) {
 		},
 		{
 			name: "double wrapped error with params",
-			err: Wrap(Wrap(
-				Error("inner0Message", SafeParam("inner0ParamKey", "inner0VParamValue"), SafeParam("inner0ParamKey1", "inner0VParamValue1"), SafeParam("inner0ParamKey2", "inner0VParamValue2")),
+			err: WrapWithContextParams(context.Background(), WrapWithContextParams(context.Background(),
+				ErrorWithContextParams(context.Background(), "inner0Message", SafeParam("inner0ParamKey", "inner0VParamValue"), SafeParam("inner0ParamKey1", "inner0VParamValue1"), SafeParam("inner0ParamKey2", "inner0VParamValue2")),
 				"inner1Message", SafeParam("inner1ParamKey", "inner1ValueKey")), "inner2Message"),
 			expectedRegex: "" +
 				"inner2Message\n" +

--- a/werror_test.go
+++ b/werror_test.go
@@ -43,7 +43,7 @@ func TestError_Format(t *testing.T) {
 	}{
 		{
 			name: "new error without safe params",
-			err: werror.Error("message",
+			err: werror.ErrorWithContextParams(context.Background(), "message",
 				werror.UnsafeParam("unsafeKey", "unsafeKey"),
 			),
 			stringified: "message",
@@ -58,7 +58,7 @@ runtime.goexit
 		},
 		{
 			name: "new error with params",
-			err: werror.Error("message",
+			err: werror.ErrorWithContextParams(context.Background(), "message",
 				werror.UnsafeParam("unsafeKey", "unsafeKey"),
 				werror.SafeParam("safeKey", paramObject{
 					A: "public value A",
@@ -78,9 +78,9 @@ runtime.goexit
 		},
 		{
 			name: "error wrapped with errors and werror",
-			err: werror.Wrap(
+			err: werror.WrapWithContextParams(context.Background(),
 				errors.Wrap(
-					werror.Error(
+					werror.ErrorWithContextParams(context.Background(),
 						"root cause",
 						werror.UnsafeParam("unsafeRootKey", "unsafeRootValue"),
 						werror.SafeParam("safeRootKey", "safeRootValue"),
@@ -119,8 +119,8 @@ runtime.goexit
 		},
 		{
 			name: "wrapped with empty string",
-			err: werror.Wrap(
-				werror.Error("rootcause"),
+			err: werror.WrapWithContextParams(context.Background(),
+				werror.ErrorWithContextParams(context.Background(), "rootcause"),
 				"",
 			),
 			stringified: "rootcause",
@@ -142,8 +142,8 @@ runtime.goexit
 		},
 		{
 			name: "wrapped with empty string and params",
-			err: werror.Wrap(
-				werror.Error("rootcause"),
+			err: werror.WrapWithContextParams(context.Background(),
+				werror.ErrorWithContextParams(context.Background(), "rootcause"),
 				"",
 				werror.SafeParam("safeEmptyWrapperKey", "safeEmptyWrapperValue"),
 				werror.UnsafeParam("unsafeWrapperKey", "unsafeWrapperValue"),
@@ -167,7 +167,7 @@ runtime.goexit
 		},
 		{
 			name: "wrapped custom error with params",
-			err: werror.Wrap(
+			err: werror.WrapWithContextParams(context.Background(),
 				fmt.Errorf("customErr"),
 				"wrapper",
 				werror.SafeParam("safeWrapperKey", "safeWrapperValue"),
@@ -231,7 +231,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with the same safe and unsafe param key",
-			err: werror.ErrorWithContext(context.Background(), "err",
+			err: werror.ErrorWithContextParams(context.Background(), "err",
 				werror.SafeParam("key", "safeValue"),
 				werror.UnsafeParam("key", "unsafeValue")),
 			wantSafeParams: map[string]interface{}{},
@@ -241,7 +241,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with the same safe and unsafe param key (reverse order)",
-			err: werror.ErrorWithContext(context.Background(), "err",
+			err: werror.ErrorWithContextParams(context.Background(), "err",
 				werror.UnsafeParam("key", "unsafeValue"),
 				werror.SafeParam("key", "safeValue")),
 			wantSafeParams: map[string]interface{}{
@@ -251,9 +251,9 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with nested params",
-			err: werror.WrapWithContext(context.Background(),
+			err: werror.WrapWithContextParams(context.Background(),
 				errors.Wrap(
-					werror.ErrorWithContext(context.Background(),
+					werror.ErrorWithContextParams(context.Background(),
 						"root cause",
 						werror.UnsafeParam("unsafeRootKey", "unsafeRootValue"),
 						werror.SafeParam("safeRootKey", "safeRootValue"),
@@ -275,7 +275,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with empty safe and unsafe params param",
-			err: werror.ErrorWithContext(context.Background(), "error",
+			err: werror.ErrorWithContextParams(context.Background(), "error",
 				werror.SafeAndUnsafeParams(
 					map[string]interface{}{},
 					map[string]interface{}{},
@@ -286,7 +286,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with safe and unsafe params param",
-			err: werror.ErrorWithContext(context.Background(), "error",
+			err: werror.ErrorWithContextParams(context.Background(), "error",
 				werror.SafeAndUnsafeParams(
 					map[string]interface{}{
 						"safeKey": "safeVal",
@@ -329,22 +329,22 @@ func TestParamFromError(t *testing.T) {
 		err:  nil,
 	}, {
 		name: "error without param",
-		err:  werror.ErrorWithContext(context.Background(), "err"),
+		err:  werror.ErrorWithContextParams(context.Background(), "err"),
 	}, {
 		name: "error with safe param",
-		err: werror.ErrorWithContext(context.Background(), "err",
+		err: werror.ErrorWithContextParams(context.Background(), "err",
 			werror.SafeParam("key", "value")),
 		expectedValue: "value",
 		expectedSafe:  true,
 	}, {
 		name: "error with unsafe param",
-		err: werror.ErrorWithContext(context.Background(), "err",
+		err: werror.ErrorWithContextParams(context.Background(), "err",
 			werror.UnsafeParam("key", "value")),
 		expectedValue: "value",
 		expectedSafe:  false,
 	}, {
 		name: "error with duplicated param",
-		err: werror.ErrorWithContext(context.Background(), "err",
+		err: werror.ErrorWithContextParams(context.Background(), "err",
 			werror.UnsafeParam("key", "value1"),
 			werror.SafeParam("key", "value2"),
 			werror.SafeParam("key", "value3"),
@@ -370,7 +370,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 	}{
 		{
 			name: "empty parameterStorer",
-			inErr: werror.ErrorWithContext(context.Background(),
+			inErr: werror.ErrorWithContextParams(context.Background(),
 				"error",
 				werror.Params(testParameterStorerObject{}),
 			),
@@ -379,7 +379,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 		},
 		{
 			name: "parameterStorer with safe and unsafe params",
-			inErr: werror.ErrorWithContext(context.Background(),
+			inErr: werror.ErrorWithContextParams(context.Background(),
 				"error",
 				werror.Params(testParameterStorerObject{
 					safeParams: map[string]interface{}{
@@ -417,7 +417,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 		},
 		{
 			name: "werror with non-werror ParamStorer error cause",
-			inErr: werror.WrapWithContext(context.Background(),
+			inErr: werror.WrapWithContextParams(context.Background(),
 				&customParamStorerError{
 					msg: "error",
 					safeParams: map[string]interface{}{
@@ -474,10 +474,10 @@ func TestConvert(t *testing.T) {
 		err:  fmt.Errorf("custom error"),
 	}, {
 		name: "werror error",
-		err:  werror.ErrorWithContext(context.Background(), "werror error"),
+		err:  werror.ErrorWithContextParams(context.Background(), "werror error"),
 	}, {
 		name: "wrapped custom error",
-		err:  werror.WrapWithContext(context.Background(), fmt.Errorf("custom error"), "wrapped error"),
+		err:  werror.WrapWithContextParams(context.Background(), fmt.Errorf("custom error"), "wrapped error"),
 	}} {
 		t.Run(currCase.name, func(t *testing.T) {
 			if currCase.err == nil {
@@ -493,11 +493,11 @@ func TestConvert(t *testing.T) {
 }
 
 func TestWrap_NilErrorIsNil(t *testing.T) {
-	require.Nil(t, werror.WrapWithContext(context.Background(), nil, "<-- nil!"), "werror.WrapWithContext(context.Background(), )(nil) was not nil")
+	require.Nil(t, werror.WrapWithContextParams(context.Background(), nil, "<-- nil!"), "werror.WrapWithContext(context.Background(), )(nil) was not nil")
 }
 
 func TestRootCause(t *testing.T) {
-	werrorErr := werror.ErrorWithContext(context.Background(), "werror err")
+	werrorErr := werror.ErrorWithContextParams(context.Background(), "werror err")
 	customErr := fmt.Errorf("custom err")
 	for _, currCase := range []struct {
 		name      string
@@ -514,7 +514,7 @@ func TestRootCause(t *testing.T) {
 	}, {
 		name:      "wrapped werror error",
 		rootCause: werrorErr,
-		err:       werror.WrapWithContext(context.Background(), werrorErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
+		err:       werror.WrapWithContextParams(context.Background(), werrorErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
 	}, {
 		name:      "converted werror error",
 		rootCause: werrorErr,
@@ -526,7 +526,7 @@ func TestRootCause(t *testing.T) {
 	}, {
 		name:      "wrapped custom error",
 		rootCause: customErr,
-		err:       werror.WrapWithContext(context.Background(), customErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
+		err:       werror.WrapWithContextParams(context.Background(), customErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
 	}, {
 		name:      "converted custom error",
 		rootCause: customErr,
@@ -543,7 +543,7 @@ func TestErrorPullsOutParamsFromContext(t *testing.T) {
 	safe := map[string]interface{}{"safeKey": "safeValue"}
 	unsafe := map[string]interface{}{"unsafeKey": "unsafeValue"}
 	ctx = wparams.ContextWithSafeAndUnsafeParams(ctx, safe, unsafe)
-	err := werror.ErrorWithContext(ctx, "error", werror.SafeParam("anotherSafeKey", "anotherSafeValue"), werror.UnsafeParam("anotherUnsafeKey", "anotherUnsafeValue"))
+	err := werror.ErrorWithContextParams(ctx, "error", werror.SafeParam("anotherSafeKey", "anotherSafeValue"), werror.UnsafeParam("anotherUnsafeKey", "anotherUnsafeValue"))
 	safeFromError, unSafeFromError := werror.ParamsFromError(err)
 	assert.Equal(t, map[string]interface{}{"safeKey": "safeValue", "anotherSafeKey": "anotherSafeValue"}, safeFromError)
 	assert.Equal(t, map[string]interface{}{"unsafeKey": "unsafeValue", "anotherUnsafeKey": "anotherUnsafeValue"}, unSafeFromError)
@@ -555,7 +555,7 @@ func TestWrapPullsOutParamsFromContext(t *testing.T) {
 	unsafe := map[string]interface{}{"unsafeKey": "unsafeValue"}
 	ctx = wparams.ContextWithSafeAndUnsafeParams(ctx, safe, unsafe)
 	rawErr := werror.Error("err", werror.SafeParam("anotherSafeKey", "anotherSafeValue"), werror.UnsafeParam("anotherUnsafeKey", "anotherUnsafeValue"))
-	err := werror.WrapWithContext(ctx, rawErr, "bad", werror.SafeParam("aThirdSafeKey", "aThirdSafeValue"), werror.UnsafeParam("aThirdUnsafeKey", "aThirdUnsafeValue"))
+	err := werror.WrapWithContextParams(ctx, rawErr, "bad", werror.SafeParam("aThirdSafeKey", "aThirdSafeValue"), werror.UnsafeParam("aThirdUnsafeKey", "aThirdUnsafeValue"))
 	safeFromError, unSafeFromError := werror.ParamsFromError(err)
 	assert.Equal(t, map[string]interface{}{"safeKey": "safeValue", "anotherSafeKey": "anotherSafeValue", "aThirdSafeKey": "aThirdSafeValue"}, safeFromError)
 	assert.Equal(t, map[string]interface{}{"unsafeKey": "unsafeValue", "anotherUnsafeKey": "anotherUnsafeValue", "aThirdUnsafeKey": "aThirdUnsafeValue"}, unSafeFromError)

--- a/werror_test.go
+++ b/werror_test.go
@@ -1,6 +1,7 @@
 package werror_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -48,15 +49,15 @@ func TestError_Format(t *testing.T) {
 			verbose:     `message`,
 			extraVerboseRegexp: `^message
 ` + pkgPath + `_test.TestError_Format
-	.+
+       .+
 testing.tRunner
-	.+
-runtime.goexit
-	.+$`,
+       .+
+ runtime.goexit
+        .+$`,
 		},
 		{
 			name: "new error with params",
-			err: werror.Error("message",
+			err: werror.Error( "message",
 				werror.UnsafeParam("unsafeKey", "unsafeKey"),
 				werror.SafeParam("safeKey", paramObject{
 					A: "public value A",
@@ -141,7 +142,7 @@ runtime.goexit
 		{
 			name: "wrapped with empty string and params",
 			err: werror.Wrap(
-				werror.Error("rootcause"),
+				werror.Error( "rootcause"),
 				"",
 				werror.SafeParam("safeEmptyWrapperKey", "safeEmptyWrapperValue"),
 				werror.UnsafeParam("unsafeWrapperKey", "unsafeWrapperValue"),
@@ -229,7 +230,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with the same safe and unsafe param key",
-			err: werror.Error("err",
+			err: werror.ErrorWithContext(context.Background(), "err",
 				werror.SafeParam("key", "safeValue"),
 				werror.UnsafeParam("key", "unsafeValue")),
 			wantSafeParams: map[string]interface{}{},
@@ -239,7 +240,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with the same safe and unsafe param key (reverse order)",
-			err: werror.Error("err",
+			err: werror.ErrorWithContext(context.Background(), "err",
 				werror.UnsafeParam("key", "unsafeValue"),
 				werror.SafeParam("key", "safeValue")),
 			wantSafeParams: map[string]interface{}{
@@ -249,9 +250,9 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with nested params",
-			err: werror.Wrap(
+			err: werror.WrapWithContext(context.Background(),
 				errors.Wrap(
-					werror.Error(
+					werror.ErrorWithContext(context.Background(),
 						"root cause",
 						werror.UnsafeParam("unsafeRootKey", "unsafeRootValue"),
 						werror.SafeParam("safeRootKey", "safeRootValue"),
@@ -273,7 +274,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with empty safe and unsafe params param",
-			err: werror.Error("error",
+			err: werror.ErrorWithContext(context.Background(), "error",
 				werror.SafeAndUnsafeParams(
 					map[string]interface{}{},
 					map[string]interface{}{},
@@ -284,7 +285,7 @@ func TestParamsFromError(t *testing.T) {
 		},
 		{
 			name: "with safe and unsafe params param",
-			err: werror.Error("error",
+			err: werror.ErrorWithContext(context.Background(), "error",
 				werror.SafeAndUnsafeParams(
 					map[string]interface{}{
 						"safeKey": "safeVal",
@@ -327,22 +328,22 @@ func TestParamFromError(t *testing.T) {
 		err:  nil,
 	}, {
 		name: "error without param",
-		err:  werror.Error("err"),
+		err:  werror.ErrorWithContext(context.Background(), "err"),
 	}, {
 		name: "error with safe param",
-		err: werror.Error("err",
+		err: werror.ErrorWithContext(context.Background(), "err",
 			werror.SafeParam("key", "value")),
 		expectedValue: "value",
 		expectedSafe:  true,
 	}, {
 		name: "error with unsafe param",
-		err: werror.Error("err",
+		err: werror.ErrorWithContext(context.Background(), "err",
 			werror.UnsafeParam("key", "value")),
 		expectedValue: "value",
 		expectedSafe:  false,
 	}, {
 		name: "error with duplicated param",
-		err: werror.Error("err",
+		err: werror.ErrorWithContext(context.Background(), "err",
 			werror.UnsafeParam("key", "value1"),
 			werror.SafeParam("key", "value2"),
 			werror.SafeParam("key", "value3"),
@@ -368,7 +369,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 	}{
 		{
 			name: "empty parameterStorer",
-			inErr: werror.Error(
+			inErr: werror.ErrorWithContext(context.Background(),
 				"error",
 				werror.Params(testParameterStorerObject{}),
 			),
@@ -377,7 +378,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 		},
 		{
 			name: "parameterStorer with safe and unsafe params",
-			inErr: werror.Error(
+			inErr: werror.ErrorWithContext(context.Background(),
 				"error",
 				werror.Params(testParameterStorerObject{
 					safeParams: map[string]interface{}{
@@ -415,7 +416,7 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 		},
 		{
 			name: "werror with non-werror ParamStorer error cause",
-			inErr: werror.Wrap(
+			inErr: werror.WrapWithContext(context.Background(),
 				&customParamStorerError{
 					msg: "error",
 					safeParams: map[string]interface{}{
@@ -472,10 +473,10 @@ func TestConvert(t *testing.T) {
 		err:  fmt.Errorf("custom error"),
 	}, {
 		name: "werror error",
-		err:  werror.Error("werror error"),
+		err:  werror.ErrorWithContext(context.Background(), "werror error"),
 	}, {
 		name: "wrapped custom error",
-		err:  werror.Wrap(fmt.Errorf("custom error"), "wrapped error"),
+		err:  werror.WrapWithContext(context.Background(), fmt.Errorf("custom error"), "wrapped error"),
 	}} {
 		t.Run(currCase.name, func(t *testing.T) {
 			if currCase.err == nil {
@@ -491,11 +492,11 @@ func TestConvert(t *testing.T) {
 }
 
 func TestWrap_NilErrorIsNil(t *testing.T) {
-	require.Nil(t, werror.Wrap(nil, "<-- nil!"), "werror.Wrap(nil) was not nil")
+	require.Nil(t, werror.WrapWithContext(context.Background(), nil, "<-- nil!"), "werror.WrapWithContext(context.Background(), )(nil) was not nil")
 }
 
 func TestRootCause(t *testing.T) {
-	werrorErr := werror.Error("werror err")
+	werrorErr := werror.ErrorWithContext(context.Background(), "werror err")
 	customErr := fmt.Errorf("custom err")
 	for _, currCase := range []struct {
 		name      string
@@ -512,7 +513,7 @@ func TestRootCause(t *testing.T) {
 	}, {
 		name:      "wrapped werror error",
 		rootCause: werrorErr,
-		err:       werror.Wrap(werrorErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
+		err:       werror.WrapWithContext(context.Background(), werrorErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
 	}, {
 		name:      "converted werror error",
 		rootCause: werrorErr,
@@ -524,7 +525,7 @@ func TestRootCause(t *testing.T) {
 	}, {
 		name:      "wrapped custom error",
 		rootCause: customErr,
-		err:       werror.Wrap(customErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
+		err:       werror.WrapWithContext(context.Background(), customErr, "wrap", werror.SafeParam("safeKey", "safeVal")),
 	}, {
 		name:      "converted custom error",
 		rootCause: customErr,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- Often times important debugging information is attached as a param that is lost when propagating errors. An example is:

```
func TestErrorLoss(t *testing.T) {
	ctx := testutil.GetTestContext()
	err := subFunction(ctx, false)
	if err != nil {
		svc1log.FromContext(ctx).Info("work failed", svc1log.Stacktrace(err))
	}
	err = subFunction(ctx, true)
	if err != nil {
		svc1log.FromContext(ctx).Info("work failed", svc1log.Stacktrace(err))
	}
}

func subFunction(ctx context.Context, shouldError bool) error {
	ctx = svc1log.WithLoggerParams(ctx, svc1log.SafeParam("id", getId()))
	svc1log.FromContext(ctx).Info("starting work")
	err := doWork(shouldError)
	if err != nil {
		return err
	}
	svc1log.FromContext(ctx).Info("work finished")
	return nil
}

func doWork(shouldError bool) error {
	if shouldError {
		return werror.Error("bad")
	}
	return nil
}

func getId() int {
	s1 := rand.NewSource(time.Now().UnixNano())
	r1 := rand.New(s1)
	return r1.Int()
}

{"level":"INFO","time":"2020-02-10T19:25:47.808149Z","message":"starting work","type":"service.1","params":{"id":3918554832054292914}}
{"level":"INFO","time":"2020-02-10T19:25:47.808205Z","message":"work finished","type":"service.1","params":{"id":3918554832054292914}}
{"level":"INFO","time":"2020-02-10T19:25:47.80827Z","message":"starting work","type":"service.1","params":{"id":3374498929763775452}}
{"level":"INFO","time":"2020-02-10T19:25:47.808463Z","message":"work failed","type":"service.1","stacktrace":"bad\n\ngithub.palantir.build/deployability/discovery-generator/differ_test.doWork\n\t/Users/ksimons/go/src/github.palantir.build/deployability/discovery-generator/differ/discovery_entry_spec_constructor_test.go:51\ngithub.palantir.build/deployability/discovery-generator/differ_test.subFunction\n\t/Users/ksimons/go/src/github.palantir.build/deployability/discovery-generator/differ/discovery_entry_spec_constructor_test.go:41\ngithub.palantir.build/deployability/discovery-generator/differ_test.TestErrorLoss\n\t/Users/ksimons/go/src/github.palantir.build/deployability/discovery-generator/differ/discovery_entry_spec_constructor_test.go:32\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:909\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1357"}
```
- Here we can see that the id has been lost when logging the error mesage
- This is because any params wparams stored on the context are by default dropped when wrapping and creating errors
- I would like to deprecate this original `Wrap` and `Error` calls and introduce one with a context that will automatically pull out params for users
- If agreed upon, will put up some tests


## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/33)
<!-- Reviewable:end -->
