### PR TITLE
fix: Handle nil ParamStorer

### DIFF
--- a/changelog/@unreleased/pr-53.v2.yml
+++ b/changelog/@unreleased/pr-53.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'fix: Handle nil ParamStorer'
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/53

--- a/params.go
+++ b/params.go
@@ -50,7 +50,9 @@ func SafeAndUnsafeParams(safe, unsafe map[string]interface{}) Param {
 
 func Params(object wparams.ParamStorer) Param {
 	return param(func(z *werror) {
-		SafeParams(object.SafeParams()).apply(z)
-		UnsafeParams(object.UnsafeParams()).apply(z)
+		if object != nil {
+			SafeParams(object.SafeParams()).apply(z)
+			UnsafeParams(object.UnsafeParams()).apply(z)
+		}
 	})
 }

--- a/werror_test.go
+++ b/werror_test.go
@@ -378,6 +378,15 @@ func TestParamsFromError_FromParameterStorerObject(t *testing.T) {
 			wantUnsafeParams: map[string]interface{}{},
 		},
 		{
+			name: "nil parameterStorer",
+			inErr: werror.ErrorWithContextParams(context.Background(),
+				"error",
+				werror.Params(nil),
+			),
+			wantSafeParams:   map[string]interface{}{},
+			wantUnsafeParams: map[string]interface{}{},
+		},
+		{
 			name: "parameterStorer with safe and unsafe params",
 			inErr: werror.ErrorWithContextParams(context.Background(),
 				"error",


### PR DESCRIPTION
I noticed this mentioned in https://github.com/palantir/witchcraft-go-params/pull/27

==COMMIT_MSG==
fix: Handle nil ParamStorer
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/53)
<!-- Reviewable:end -->
