### PR TITLE
Fix: Fix stack traces for Error and Wrap constructors

### DIFF
--- a/changelog/@unreleased/pr-55.v2.yml
+++ b/changelog/@unreleased/pr-55.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix stack traces for Error and Wrap constructors by calling newWerror directly, which correctly avoids including the Error or Wrap function in the stacktrace.
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/55

--- a/werror.go
+++ b/werror.go
@@ -14,7 +14,7 @@ var _ Werror = (*werror)(nil)
 // DEPRECATED: Please use ErrorWithContextParams instead to ensure that all the wparams parameters that are set on the
 // context are included in the error.
 func Error(msg string, params ...Param) error {
-	return ErrorWithContextParams(context.Background(), msg, params...)
+	return newWerror(msg, nil, params...)
 }
 
 // ErrorWithContextParams returns a new error with the provided message and parameters. The returned error also includes any
@@ -44,7 +44,7 @@ func ErrorWithContextParams(ctx context.Context, msg string, params ...Param) er
 // DEPRECATED: Please use WrapWithContextParams instead to ensure that all the wparams parameters that are set on the
 // context are included in the error.
 func Wrap(err error, msg string, params ...Param) error {
-	return WrapWithContextParams(context.Background(), err, msg, params...)
+	return newWerror(msg, err, params...)
 }
 
 // WrapWithContextParams returns a new error with the provided message and stores the provided error as its cause.


### PR DESCRIPTION
## Before this PR
Because both `Error` and `Wrap` constructors included an intermediate call before calling `newWerror`, these function names ended up in the stack trace.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix stack traces for Error and Wrap constructors by calling `newWerror` directly, which correctly avoids including the Error or Wrap function in the stacktrace.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/55)
<!-- Reviewable:end -->
