### PR TITLE
Fix Wrap to return nil if err is nil

### DIFF
--- a/changelog/@unreleased/pr-57.v2.yml
+++ b/changelog/@unreleased/pr-57.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix Wrap to return nil if err is nil
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/57

--- a/werror.go
+++ b/werror.go
@@ -44,6 +44,9 @@ func ErrorWithContextParams(ctx context.Context, msg string, params ...Param) er
 // DEPRECATED: Please use WrapWithContextParams instead to ensure that all the wparams parameters that are set on the
 // context are included in the error.
 func Wrap(err error, msg string, params ...Param) error {
+	if err == nil {
+		return nil
+	}
 	return newWerror(msg, err, params...)
 }
 

--- a/werror_test.go
+++ b/werror_test.go
@@ -501,8 +501,12 @@ func TestConvert(t *testing.T) {
 	}
 }
 
-func TestWrap_NilErrorIsNil(t *testing.T) {
+func TestWrapWithContextParams_NilErrorIsNil(t *testing.T) {
 	require.Nil(t, werror.WrapWithContextParams(context.Background(), nil, "<-- nil!"), "werror.WrapWithContext(context.Background(), )(nil) was not nil")
+}
+
+func TestWrap_NilErrorIsNil(t *testing.T) {
+	require.Nil(t, werror.Wrap(nil, "<-- nil"))
 }
 
 func TestRootCause(t *testing.T) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Fixes 0429bb86d958450664e061bcdbea212a10650a82.

Via 0429bb86d958450664e061bcdbea212a10650a82 the behavior of `werror.Wrap` changed making it not return `nil` if a a `nil` error was passed.

@asanderson15 for SA.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix Wrap to return nil if err is nil
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/57)
<!-- Reviewable:end -->
