### PR TITLE
Implement Unwrap function for *werror

### DIFF
--- a/changelog/@unreleased/pr-65.v2.yml
+++ b/changelog/@unreleased/pr-65.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Errors returned by `werror.Wrap*` functions now implement the `Unwrap() error` function, which allows them to be unwrapped properly by the Go `errors` package for operations such as `errors.Is` and `errors.As`.
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/65

--- a/werror.go
+++ b/werror.go
@@ -242,6 +242,11 @@ func (e *werror) Cause() error {
 	return e.cause
 }
 
+// Unwrap returns the wrapped error. Exists to support Go error Is/As functions introduced in Go 1.13.
+func (e *werror) Unwrap() error {
+	return e.cause
+}
+
 // StackTrace returns the Stacktracer for this error or nil if there is none.
 func (e *werror) StackTrace() StackTrace {
 	return e.stack


### PR DESCRIPTION
Adds an Unwrap implementation for *werror that returns the cause
as the wrapped error. This allows the error to implement proper
wrapping behavior for Go error handling.

Fixes #64

## Before this PR
Errors returned by `werror.Wrap*` do not handle unwrapping using the Go `error` library.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Errors returned by `werror.Wrap*` functions now implement the `Unwrap() error` function, which allows them to be unwrapped properly by the Go `errors` package for operations such as `errors.Is` and `errors.As`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/65)
<!-- Reviewable:end -->
