### PR TITLE
fix: GenerateErrorString dereferences params that are pointers

### DIFF
--- a/changelog/@unreleased/pr-231.v2.yml
+++ b/changelog/@unreleased/pr-231.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: GenerateErrorStrings dereferences params that are pointers
+  links:
+  - https://github.com/palantir/witchcraft-go-error/pull/231

--- a/werror_printer.go
+++ b/werror_printer.go
@@ -3,6 +3,7 @@ package werror
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 )
 
@@ -53,7 +54,11 @@ func writeParams(err Werror, buffer *bytes.Buffer) {
 		buffer.WriteString(" ")
 	}
 	for _, safeKey := range safeKeys {
-		buffer.WriteString(fmt.Sprintf("%+v:%+v", safeKey, safeParams[safeKey]))
+		safeValue := safeParams[safeKey]
+		if v := reflect.ValueOf(safeValue); v.Kind() == reflect.Ptr && !v.IsNil() {
+			safeValue = v.Elem().Interface()
+		}
+		buffer.WriteString(fmt.Sprintf("%+v:%+v", safeKey, safeValue))
 		// If it is not the last param, add a separator
 		if !(safeKeys[len(safeKeys)-1] == safeKey) {
 			buffer.WriteString(", ")

--- a/werror_printer_test.go
+++ b/werror_printer_test.go
@@ -85,8 +85,7 @@ func TestErrorFormatting(t *testing.T) {
 		},
 	} {
 		t.Run(currCase.name, func(t *testing.T) {
-			errString := GenerateErrorString(currCase.err, currCase.outputEveryCallingStack)
-			assert.Regexp(t, currCase.expectedRegex, errString)
+			assert.Regexp(t, currCase.expectedRegex, GenerateErrorString(currCase.err, currCase.outputEveryCallingStack))
 		})
 	}
 }

--- a/werror_printer_test.go
+++ b/werror_printer_test.go
@@ -72,9 +72,21 @@ func TestErrorFormatting(t *testing.T) {
 				"inner0Message inner0ParamKey:inner0VParamValue, inner0ParamKey1:inner0VParamValue1, inner0ParamKey2:inner0VParamValue2\n\n" +
 				stackTraceString,
 		},
+		{
+			name: "error with pointer params",
+			err: ErrorWithContextParams(context.Background(), "simple_error",
+				SafeParam("key1", &[]string{"value"}[0]),
+				SafeParam("key2", &[]int{42}[0]),
+				SafeParam("key3", (*string)(nil)),
+			),
+			expectedRegex: "" +
+				"simple_error key1:value, key2:42, key3:<nil>\n\n" +
+				stackTraceString,
+		},
 	} {
 		t.Run(currCase.name, func(t *testing.T) {
-			assert.Regexp(t, currCase.expectedRegex, GenerateErrorString(currCase.err, currCase.outputEveryCallingStack))
+			errString := GenerateErrorString(currCase.err, currCase.outputEveryCallingStack)
+			assert.Regexp(t, currCase.expectedRegex, errString)
 		})
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-error/231)
<!-- Reviewable:end -->
